### PR TITLE
kcm-fcitx5 replaced by fcitx5-configtool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /pkg/
 /src/
-*.pkg.tar.xz
+*.pkg.tar*

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -78,9 +78,9 @@ package_manjaro-asian-input-support-fcitx5() {
 	depends=(
 		'fcitx5-qt'  # QT input module
 		'fcitx5-gtk' # GTK input module
+		'fcitx5-configtool'
 	)
 	optdepends=(
-		'kcm-fcitx5: KDE configuration module'
 		'fcitx5-chinese-addons: 简体中文 | Simplified Chinese'
 		'fcitx5-rime: 繁體中文 | Traditional Chinese'
 		'fcitx5-anthy: 日本語 | Japanese'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -34,6 +34,7 @@ pkgver() {
 
 package_manjaro-asian-input-support-ibus() {
 	pkgdesc='Manjaro asian input support for ibus'
+	depends=('ibus')
 	optdepends=(
 		'ibus-libpinyin: 中文 | Chinese'
 		'ibus-anthy: 日本語 | Japanese'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=(
 	"$pkgbase-fcitx5"
 	"$pkgbase-ibus"
 )
-pkgver=2020.08
+pkgver=2020.12
 pkgrel=1
 arch=('any')
 url="https://gitlab.manjaro.org/packages/community/manjaro-asian-input-support"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Stefano Capitani <stefanoatmanjarodororg>
-# Contributors: star2000 <i@star2000.work>
+# Contributor: star2000 <i@star2000.work>
+# Contributor: Sam L. Yes <manjaroyes123@outlook.com>
 
 pkgbase=manjaro-asian-input-support
 pkgname=(


### PR DESCRIPTION
`kcm-fcitx5` is replaced by `fcitx5-configtool`. As `manjaro-asian-input-support-fcitx` depends on `fcitx-configtool`, I added `fcitx5-configtool` as a required dependency.
BTW, `ibus` seems to be a missing dependency of `manjaro-asian-input-support-ibus`, and I added it in a commit.