### PR TITLE
remove fcitx5.desktop

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,16 +17,14 @@ source=(
 	'enable-fcitx.sh'
 	'enable-fcitx5.sh'
 	'enable-ibus.sh'
-	'fcitx5.desktop'
 	'fcitx5.profile'
 	'ibus.desktop'
 )
 md5sums=('fdbfae1bba8012daf984a76d7004ae3e'
-	'c2db30f540511de31de3ae28224a1f97'
-	'b974be25b7f91c392009cb8d9f1bd5b4'
-	'97a5be2b8ff8c0fc895d9ef21531e698'
-	'3578677a7102c9f8be3b9f7ea7d3d06f'
-	'f1a9f3406f8268383149889f4816cd52')
+         'c2db30f540511de31de3ae28224a1f97'
+         'b974be25b7f91c392009cb8d9f1bd5b4'
+         '3578677a7102c9f8be3b9f7ea7d3d06f'
+         'f1a9f3406f8268383149889f4816cd52')
 install=input-support.install
 
 pkgver() {
@@ -93,6 +91,5 @@ package_manjaro-asian-input-support-fcitx5() {
 		"$pkgbase-ibus"
 	)
 	install -Dm644 "$srcdir/enable-fcitx5.sh" "$pkgdir/etc/profile.d/input-support.sh"
-	install -Dm644 "$srcdir/fcitx5.desktop" "$pkgdir/etc/xdg/autostart/fcitx5.desktop"
 	install -Dm644 "$srcdir/fcitx5.profile" "$pkgdir/etc/xdg/fcitx5/profile"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ pkgname=(
 	"$pkgbase-ibus"
 )
 pkgver=2020.12
-pkgrel=1
+pkgrel=2
 arch=('any')
 url="https://gitlab.manjaro.org/packages/community/manjaro-asian-input-support"
 license=('GPL')
@@ -21,10 +21,10 @@ source=(
 	'ibus.desktop'
 )
 md5sums=('fdbfae1bba8012daf984a76d7004ae3e'
-         'c2db30f540511de31de3ae28224a1f97'
-         'b974be25b7f91c392009cb8d9f1bd5b4'
-         '3578677a7102c9f8be3b9f7ea7d3d06f'
-         'f1a9f3406f8268383149889f4816cd52')
+	'c2db30f540511de31de3ae28224a1f97'
+	'b974be25b7f91c392009cb8d9f1bd5b4'
+	'3578677a7102c9f8be3b9f7ea7d3d06f'
+	'f1a9f3406f8268383149889f4816cd52')
 install=input-support.install
 
 pkgver() {

--- a/fcitx5.desktop
+++ b/fcitx5.desktop
@@ -1,5 +1,0 @@
-[Desktop Entry]
-Name=Fcitx5
-Type=Application
-Exec=fcitx5
-Terminal=false


### PR DESCRIPTION
The autostart config file is included in `fcitx5` as /etc/xdg/autostart/org.fcitx.Fcitx5.desktop, so we don't need to create another.